### PR TITLE
Add backend server tests and docs

### DIFF
--- a/stt_dev/README.md
+++ b/stt_dev/README.md
@@ -1,0 +1,28 @@
+# STT Development Package
+
+This package contains a small collection of speech-to-text utilities and example
+FastAPI servers used for testing. The key components are:
+
+- **stt_server** – exposes endpoints for transcribing existing audio files.
+- **backend_server** – accepts uploaded audio and returns a transcript.
+- **telegram_server** – example integration with a Telegram bot.
+- **utils** – helper modules for configuration, logging and file management.
+
+## Running the Servers
+
+Each server can be started with `uvicorn` or run directly when modules provide a
+`main` entry point. They rely on environment variables defined in `.env`.
+
+```
+uvicorn stt_dev.stt_server.server:app --reload
+uvicorn stt_dev.backend_server.server:app --reload
+```
+
+## Testing
+
+The `tests` directory contains an extensive test-suite that uses `pytest`.
+Install the dependencies from `requirements.txt` and run:
+
+```
+pytest
+```

--- a/stt_dev/tests/conftest.py
+++ b/stt_dev/tests/conftest.py
@@ -1,0 +1,9 @@
+import sys, types
+
+# Provide stub modules for missing dependencies
+sys.modules.setdefault('dotenv', types.SimpleNamespace(load_dotenv=lambda *a, **k: None))
+sys.modules.setdefault('requests', types.ModuleType('requests'))
+if not hasattr(sys.modules['requests'], 'post'):
+    def _dummy_post(*a, **k):
+        raise RuntimeError('requests.post not stubbed')
+    sys.modules['requests'].post = _dummy_post

--- a/stt_dev/tests/test_backend_handlers.py
+++ b/stt_dev/tests/test_backend_handlers.py
@@ -1,6 +1,6 @@
 import sys, pathlib, types as _types
 sys.modules.setdefault("faster_whisper", _types.SimpleNamespace(WhisperModel=object))
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "stt_dev"))
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 import stt_dev.stt_server.stt_handlers as real_handlers
 sys.modules.setdefault("stt_handlers", real_handlers)
 

--- a/stt_dev/tests/test_backend_server_endpoints.py
+++ b/stt_dev/tests/test_backend_server_endpoints.py
@@ -1,0 +1,46 @@
+import sys, pathlib, types as _types
+sys.modules.setdefault("faster_whisper", _types.SimpleNamespace(WhisperModel=object))
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+import stt_dev.stt_server.stt_handlers as real_handlers
+sys.modules.setdefault("stt_handlers", real_handlers)
+
+from fastapi.testclient import TestClient
+from stt_dev.backend_server import server as backend_server
+import pytest
+
+client = TestClient(backend_server.app, raise_server_exceptions=False)
+
+
+def test_backend_health():
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+async def _dummy_transcribe(file):
+    return {"transcript": ["ok"]}
+
+
+async def _fail_transcribe(file):
+    raise RuntimeError("boom")
+
+
+@pytest.mark.asyncio
+async def test_transcribe_endpoint_success(monkeypatch, tmp_path):
+    monkeypatch.setattr(backend_server, "transcribe", _dummy_transcribe)
+    path = tmp_path / "file.wav"
+    path.write_text("dummy")
+    with open(path, "rb") as f:
+        resp = client.post("/transcribe/", files={"file": ("file.wav", f, "audio/wav")})
+    assert resp.status_code == 200
+    assert resp.json() == {"transcript": ["ok"]}
+
+
+@pytest.mark.asyncio
+async def test_transcribe_endpoint_failure(monkeypatch, tmp_path):
+    monkeypatch.setattr(backend_server, "transcribe", _fail_transcribe)
+    path = tmp_path / "file.wav"
+    path.write_text("dummy")
+    with open(path, "rb") as f:
+        resp = client.post("/transcribe/", files={"file": ("file.wav", f, "audio/wav")})
+    assert resp.status_code == 500

--- a/stt_dev/tests/test_load.py
+++ b/stt_dev/tests/test_load.py
@@ -1,6 +1,6 @@
 import sys, pathlib, types as _types
 sys.modules.setdefault("faster_whisper", _types.SimpleNamespace(WhisperModel=object))
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "stt_dev"))
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 import stt_dev.stt_server.stt_handlers as real_handlers
 sys.modules.setdefault("stt_handlers", real_handlers)
 

--- a/stt_dev/tests/test_stt_handlers.py
+++ b/stt_dev/tests/test_stt_handlers.py
@@ -1,6 +1,6 @@
 import sys, pathlib, types as _types
 sys.modules.setdefault("faster_whisper", _types.SimpleNamespace(WhisperModel=object))
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "stt_dev"))
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 import stt_dev.stt_server.stt_handlers as real_handlers
 sys.modules.setdefault("stt_handlers", real_handlers)
 

--- a/stt_dev/tests/test_stt_server_endpoints.py
+++ b/stt_dev/tests/test_stt_server_endpoints.py
@@ -1,6 +1,6 @@
 import sys, pathlib, types as _types
 sys.modules.setdefault("faster_whisper", _types.SimpleNamespace(WhisperModel=object))
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "stt_dev"))
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 import stt_dev.stt_server.stt_handlers as real_handlers
 sys.modules.setdefault("stt_handlers", real_handlers)
 
@@ -34,7 +34,18 @@ def test_transcribe_file_success(monkeypatch, tmp_path):
     assert resp.json()["full_transcript"] == "a b"
 
 
-def test_path_traversal_rejected(monkeypatch):
-    path = "../../etc/passwd"
+@pytest.mark.parametrize("path", ["../../etc/passwd", "..\\..\\secret", "/etc/passwd"])
+def test_path_traversal_rejected(monkeypatch, path):
     resp = client.get("/transcribe-file/", params={"file_path": path, "language": "en"})
     assert resp.status_code == 500
+
+
+@pytest.mark.parametrize("lang", ["en", "es", "de"])
+def test_transcribe_file_various_languages(monkeypatch, tmp_path, lang):
+    dummy_file = tmp_path / "test.wav"
+    dummy_file.write_text("dummy")
+    monkeypatch.setattr(stt_server, "transcribe_audio", lambda fp, language="en": [lang])
+    monkeypatch.setattr(stt_server, "process_transcript", lambda t: "".join(t))
+    resp = client.get("/transcribe-file/", params={"file_path": str(dummy_file), "language": lang})
+    assert resp.status_code == 200
+    assert resp.json()["segments"] == [lang]

--- a/stt_dev/tests/test_telegram_handlers.py
+++ b/stt_dev/tests/test_telegram_handlers.py
@@ -1,7 +1,7 @@
 import sys, pathlib
 import types as _types
 sys.modules.setdefault("faster_whisper", _types.SimpleNamespace(WhisperModel=object))
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "stt_dev"))
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 import os
 import types
 import pytest

--- a/stt_dev/tests/test_utils.py
+++ b/stt_dev/tests/test_utils.py
@@ -1,5 +1,5 @@
 import sys, pathlib
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "stt_dev"))
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 import os
 import io
 import pytest


### PR DESCRIPTION
## Summary
- fix sys.path in tests
- add backend server endpoint tests
- increase test coverage with parametrized checks
- document servers in `stt_dev/README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a7cee6d7883328c3655bb0a22b2cb