### PR TITLE
Split requirements per service

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,7 @@
-faster-whisper
-python-dotenv
-openai-whisper
-python-telegram-bot
-pytest
-requests
-uvicorn
 fastapi
 python-multipart
+requests
+python-telegram-bot
+python-dotenv
+pytest
 pytest-asyncio

--- a/stt_dev/README.md
+++ b/stt_dev/README.md
@@ -9,6 +9,10 @@ The key components are:
 - **stt_server** – Server to specifically handle all STT-related functionality
 - **utils** – Helper modules for configuration, logging and file management
 
+Each server directory contains its own `Dockerfile` **and** `requirements.txt`.
+The Docker Compose configuration starts one container per server using
+these files.
+
 ## Running the Servers
 
 Use the helper script `deploy.sh` in the repository root.
@@ -26,7 +30,8 @@ folder is mounted into the containers so it persists across runs.
 ## Testing
 
 The `tests` directory contains an extensive test-suite that uses `pytest`.
-Install the dependencies from `requirements.txt` and run:
+Install the development dependencies from the repository root
+`requirements.txt` and run:
 
 ```bash
 pytest

--- a/stt_dev/backend_server/Dockerfile
+++ b/stt_dev/backend_server/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY stt_dev/backend_server/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY stt_dev ./stt_dev
+COPY stt_dev/run_server.sh /run_server.sh
+RUN chmod +x /run_server.sh
+ENV PYTHONPATH=/app
+CMD ["/run_server.sh", "stt_dev.backend_server.server", "8000"]
+

--- a/stt_dev/backend_server/requirements.txt
+++ b/stt_dev/backend_server/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+python-multipart
+faster-whisper
+python-dotenv

--- a/stt_dev/docker-compose.yml
+++ b/stt_dev/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   backend_server:
     build:
       context: ..
-      dockerfile: stt_dev/Dockerfile
+      dockerfile: stt_dev/backend_server/Dockerfile
     command: ["/run_server.sh", "stt_dev.backend_server.server", "8000"]
     volumes:
       - ..:/app
@@ -15,7 +15,7 @@ services:
   stt_server:
     build:
       context: ..
-      dockerfile: stt_dev/Dockerfile
+      dockerfile: stt_dev/stt_server/Dockerfile
     command: ["/run_server.sh", "stt_dev.stt_server.server", "8001"]
     volumes:
       - ..:/app
@@ -27,7 +27,7 @@ services:
   telegram_server:
     build:
       context: ..
-      dockerfile: stt_dev/Dockerfile
+      dockerfile: stt_dev/telegram_server/Dockerfile
     command: python -m stt_dev.telegram_server.server
     volumes:
       - ..:/app

--- a/stt_dev/stt_server/Dockerfile
+++ b/stt_dev/stt_server/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY stt_dev/stt_server/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY stt_dev ./stt_dev
+COPY stt_dev/run_server.sh /run_server.sh
+RUN chmod +x /run_server.sh
+ENV PYTHONPATH=/app
+CMD ["/run_server.sh", "stt_dev.stt_server.server", "8001"]
+

--- a/stt_dev/stt_server/requirements.txt
+++ b/stt_dev/stt_server/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+faster-whisper
+python-dotenv

--- a/stt_dev/telegram_server/Dockerfile
+++ b/stt_dev/telegram_server/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY stt_dev/telegram_server/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY stt_dev ./stt_dev
+ENV PYTHONPATH=/app
+CMD ["python", "-m", "stt_dev.telegram_server.server"]
+

--- a/stt_dev/telegram_server/requirements.txt
+++ b/stt_dev/telegram_server/requirements.txt
@@ -1,0 +1,3 @@
+python-telegram-bot
+requests
+python-dotenv


### PR DESCRIPTION
## Summary
- break up monolithic requirements into per-service files
- point each Dockerfile at its service's requirements
- adjust README about installation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a97f8c6448332b023cf4be3177ad1