### PR TITLE
Fix environment loading and imports

### DIFF
--- a/stt_dev/backend_server/backend_handlers.py
+++ b/stt_dev/backend_server/backend_handlers.py
@@ -1,10 +1,10 @@
 # backend/backend_handlers.py
 
 from fastapi import UploadFile, File, HTTPException
-from stt_server.stt_handlers import transcribe_audio
-from utils.config import UPLOAD_DIR
-from utils.logger import get_logger
-from utils.file_utils import save_upload_file, delete_file
+from ..stt_server.stt_handlers import transcribe_audio
+from ..utils.config import UPLOAD_DIR
+from ..utils.logger import get_logger
+from ..utils.file_utils import save_upload_file, delete_file
 import os
 
 logger = get_logger("backend_server")

--- a/stt_dev/backend_server/server.py
+++ b/stt_dev/backend_server/server.py
@@ -1,8 +1,8 @@
 # backend_server/server.py
 
 from fastapi import FastAPI, UploadFile, File
-from backend_server.backend_handlers import transcribe
-from utils.logger import get_logger
+from .backend_handlers import transcribe
+from ..utils.logger import get_logger
 
 logger = get_logger("backend_server")
 

--- a/stt_dev/stt_server/server.py
+++ b/stt_dev/stt_server/server.py
@@ -1,9 +1,9 @@
 # stt_server/server.py
 from fastapi import FastAPI, HTTPException, Query
-from stt_handlers import transcribe_audio, process_transcript
+from .stt_handlers import transcribe_audio, process_transcript
 import os
 
-from utils.logger import get_logger
+from ..utils.logger import get_logger
 logger = get_logger("stt_server")
 
 app = FastAPI()

--- a/stt_dev/stt_server/stt_handlers.py
+++ b/stt_dev/stt_server/stt_handlers.py
@@ -3,8 +3,8 @@ import os
 import time
 from functools import lru_cache
 from faster_whisper import WhisperModel
-from utils.config import WHISPER_DEVICE, WHISPER_COMPUTE, MODEL_SIZE
-from utils.logger import get_logger
+from ..utils.config import WHISPER_DEVICE, WHISPER_COMPUTE, MODEL_SIZE
+from ..utils.logger import get_logger
 logger = get_logger("stt_server")
 
 @lru_cache(maxsize=1)

--- a/stt_dev/telegram_server/server.py
+++ b/stt_dev/telegram_server/server.py
@@ -1,9 +1,9 @@
 # telegram_server/server.py
 
-from utils.config import BOT_TOKEN
+from ..utils.config import BOT_TOKEN
 from telegram.ext import ApplicationBuilder, MessageHandler, filters
-from telegram_server.telegram_handlers import handle_audio
-from utils.logger import get_logger
+from .telegram_handlers import handle_audio
+from ..utils.logger import get_logger
 logger = get_logger("telegram_server")
 
 def start_bot():

--- a/stt_dev/telegram_server/telegram_handlers.py
+++ b/stt_dev/telegram_server/telegram_handlers.py
@@ -3,10 +3,10 @@
 import os
 import uuid
 import requests
-from utils.config import FASTAPI_URL, UPLOAD_DIR
+from ..utils.config import FASTAPI_URL, UPLOAD_DIR
 from telegram import Update
 from telegram.ext import ContextTypes
-from utils.logger import get_logger
+from ..utils.logger import get_logger
 logger = get_logger("telegram_server")
 
 os.makedirs(UPLOAD_DIR, exist_ok=True)

--- a/stt_dev/utils/config.py
+++ b/stt_dev/utils/config.py
@@ -1,8 +1,12 @@
 # utils/config.py
 from dotenv import load_dotenv
+from pathlib import Path
 import os
 
-load_dotenv('../.env')
+# Load environment variables from a .env file located at the project root
+env_path = Path(__file__).resolve().parents[1] / '.env'
+if env_path.exists():
+    load_dotenv(env_path)
 
 WHISPER_DEVICE = os.getenv("WHISPER_DEVICE", "cuda")
 WHISPER_COMPUTE = os.getenv("WHISPER_COMPUTE", "float16")

--- a/stt_dev/utils/file_utils.py
+++ b/stt_dev/utils/file_utils.py
@@ -2,7 +2,7 @@
 
 import os
 import shutil
-from utils.logger import get_logger
+from .logger import get_logger
 
 logger = get_logger("file_utils")
 


### PR DESCRIPTION
## Summary
- load `.env` relative to the package root
- use relative imports across modules so they work as installed packages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aa92ef5508332bd2639c609cfd1eb